### PR TITLE
Handle project paths in backlink display

### DIFF
--- a/src/components/MemoLinkCardView.vue
+++ b/src/components/MemoLinkCardView.vue
@@ -49,7 +49,7 @@
             >
               <template #header>
                 <h3 class="truncate-multiline text-sm font-semibold text-gray-700">
-                  {{ truncateString(memo.title, 32) }}
+                    {{ truncateString(extractBasenameFromTitle(memo.title), 32) }}
                 </h3>
               </template>
               <img
@@ -95,7 +95,7 @@
                     }"
                   >
                     <h3 class="truncate-multiline flex flex-col items-center gap-1 text-sm font-semibold text-gray-700">
-                      {{ truncateString(link.title, 32) }}
+                      {{ truncateString(extractBasenameFromTitle(link.title), 32) }}
                       <Icon
                         :name="iconKey.link"
                         class="text-xl"
@@ -124,7 +124,7 @@
                   >
                     <template #header>
                       <h3 class="truncate-multiline text-sm font-semibold text-gray-700">
-                        {{ truncateString(thl.title, 32) }}
+                        {{ truncateString(extractBasenameFromTitle(thl.title), 32) }}
                       </h3>
                     </template>
                     <img
@@ -156,6 +156,10 @@ import type { Link } from '~/models/link';
 const props = defineProps<{
   links: Array<Link>;
 }>();
+
+function extractBasenameFromTitle(title: string): string {
+  return title.includes('/') ? title.split('/').pop() ?? title : title;
+}
 
 const route = useRoute();
 

--- a/src/components/MemoLinkList.vue
+++ b/src/components/MemoLinkList.vue
@@ -27,7 +27,7 @@
                 class="text-xs font-semibold"
               >[From]
               </span>
-              {{ link.title }}
+              {{ extractBasenameFromTitle(link.title) }}
             </NuxtLink>
           </div>
         </li>
@@ -55,7 +55,7 @@
                   class="text-xs font-bold"
                 >[From]
                 </span>
-                {{ link.title }}
+                {{ extractBasenameFromTitle(link.title) }}
               </NuxtLink>
             </div>
 
@@ -79,7 +79,7 @@
                       class="text-xs font-bold"
                     >[From]
                     </span>
-                    {{ thl.title }}
+                    {{ extractBasenameFromTitle(thl.title) }}
                   </NuxtLink>
                 </div>
               </li>
@@ -97,6 +97,10 @@ import type { Link } from '~/models/link';
 const props = defineProps<{
   links: Array<Link>;
 }>();
+
+function extractBasenameFromTitle(title: string): string {
+  return title.includes('/') ? title.split('/').pop() ?? title : title;
+}
 
 const previousRoute = usePreviousRoute();
 


### PR DESCRIPTION
## Summary
- trim project path segments when showing backlink titles

## Testing
- `npm run lint` *(fails: Cannot find module '/workspace/monobox/.nuxt/eslint.config.mjs')*

------
https://chatgpt.com/codex/tasks/task_e_685fa26bd9f0832c92be082c5471ad5c